### PR TITLE
initial implementation of component win-homepage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+*.log
+*.js
+bundle.css
+*.html
+.DS_Store
+!karma.conf.js
+assets/

--- a/example.css
+++ b/example.css
@@ -1,0 +1,28 @@
+@import './index.css';
+
+
+html {
+  box-sizing: border-box;
+}
+*, *:before, *:after {
+  box-sizing: inherit;
+}
+
+
+.ad-panel__animated {
+  transform: translateY(100px);
+  transition: all 0.4s ease-out 0.5s;
+  transition-property: opacity, transform;
+  opacity: 0;
+}
+
+.ad-panel__animated.ad-panel--visible {
+  transform: translateY(0px);
+  opacity: 1;
+}
+
+
+#component-preview {
+  max-width: 1190px;
+  margin: 0 auto;
+}

--- a/example.es6
+++ b/example.es6
@@ -1,0 +1,129 @@
+import React from 'react';
+import WinHomePage from './';
+
+const today = new Date();
+const list = [
+  {
+    image: {
+      src: `http://cdn.static-economist.com/sites/default/files/imagecache/full-width/images/articles/20140110_usd001_l.jpg`,
+      title: `Just an image`,
+    },
+    type: `default`,
+    section: `Unitied States`,
+    flyTitle: `The UN, religion and development`,
+    title: `Mid-term showdown`,
+    dateTime: today,
+    text: `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+    eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+    minim veniam.`,
+    link: {
+      href: `http://www.economist.com/blogs/erasmus/2015/09/`,
+    },
+    itemType: ``,
+    itemProp: ``,
+    teaserId: `1`,
+  },
+  {
+    image: {
+      src: `http://cdn.static-economist.com/sites/default/files/imagecache/full-width/images/articles/20140110_chp001_l.jpg`,
+      title: `Just an image`,
+    },
+    type: `default`,
+    section: `International`,
+    flyTitle: ``,
+    title: `Pedalling uphill`,
+    dateTime: today,
+    text: `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+    eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+    minim veniam.`,
+    link: {
+      href: `http://www.economist.com/blogs/erasmus/2015/09/`,
+    },
+    itemType: ``,
+    itemProp: ``,
+    teaserId: `2`,
+  },
+  {
+    image: {
+      src: `http://cdn.static-economist.com/sites/default/files/imagecache/full-width/images/articles/20140110_amp001_l.jpg`,
+      title: `Just an image`,
+    },
+    type: `default`,
+    section: `Americas`,
+    flyTitle: ``,
+    title: `Let the games begin`,
+    dateTime: today,
+    text: `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+    eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+    minim veniam.`,
+    link: {
+      href: `http://www.economist.com/blogs/erasmus/2015/09/`,
+    },
+    itemType: ``,
+    itemProp: ``,
+    teaserId: `3`,
+  },
+  {
+    image: {
+      src: `http://cdn.static-economist.com/sites/default/files/imagecache/full-width/images/articles/20140110_eup004_l.jpg`,
+      title: `Just an image`,
+    },
+    type: `default`,
+    section: `Europe`,
+    flyTitle: ``,
+    title: `Erdogan’s dilemma`,
+    dateTime: today,
+    text: `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+    eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+    minim veniam.`,
+    link: {
+      href: `http://www.economist.com/blogs/erasmus/2015/09/`,
+    },
+    itemType: ``,
+    itemProp: ``,
+    teaserId: `4`,
+  },
+  {
+    image: {
+      src: `http://cdn.static-economist.com/sites/default/files/imagecache/full-width/images/articles/20140110_ldp006_l.jpg`,
+      title: `Just an image`,
+    },
+    type: `default`,
+    section: `Leaders`,
+    flyTitle: ``,
+    title: `The coming tech-lash`,
+    dateTime: today,
+    text: `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+    eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+    minim veniam.`,
+    link: {
+      href: `http://www.economist.com/blogs/erasmus/2015/09/`,
+    },
+    itemType: ``,
+    itemProp: ``,
+    teaserId: `5`,
+  },
+  {
+    image: {
+      src: `http://cdn.static-economist.com/sites/default/files/imagecache/original-size/20151003_WOM001_473.png`,
+      title: `Just an image`,
+    },
+    type: `default`,
+    section: `Leaders`,
+    flyTitle: `The UN, religion and development`,
+    title: `Migration crisis`,
+    dateTime: today,
+    text: `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+    eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+    minim veniam.`,
+    link: {
+      href: `http://www.economist.com/blogs/erasmus/2015/09/`,
+    },
+    itemType: ``,
+    itemProp: ``,
+    teaserId: `6`,
+  },
+];
+export default (
+  <WinHomePage list={list}/>
+);

--- a/example.es6
+++ b/example.es6
@@ -2,13 +2,13 @@ import React from 'react';
 import WinHomePage from './';
 
 const today = new Date();
-const list = [
+const articleList = [
   {
     image: {
       src: `http://cdn.static-economist.com/sites/default/files/imagecache/full-width/images/articles/20140110_usd001_l.jpg`,
       title: `Just an image`,
     },
-    type: `default`,
+    variantName: `default`,
     section: `Unitied States`,
     flyTitle: `The UN, religion and development`,
     title: `Mid-term showdown`,
@@ -28,7 +28,7 @@ const list = [
       src: `http://cdn.static-economist.com/sites/default/files/imagecache/full-width/images/articles/20140110_chp001_l.jpg`,
       title: `Just an image`,
     },
-    type: `default`,
+    variantName: `default`,
     section: `International`,
     flyTitle: ``,
     title: `Pedalling uphill`,
@@ -48,7 +48,7 @@ const list = [
       src: `http://cdn.static-economist.com/sites/default/files/imagecache/full-width/images/articles/20140110_amp001_l.jpg`,
       title: `Just an image`,
     },
-    type: `default`,
+    variantName: `default`,
     section: `Americas`,
     flyTitle: ``,
     title: `Let the games begin`,
@@ -68,7 +68,7 @@ const list = [
       src: `http://cdn.static-economist.com/sites/default/files/imagecache/full-width/images/articles/20140110_eup004_l.jpg`,
       title: `Just an image`,
     },
-    type: `default`,
+    variantName: `default`,
     section: `Europe`,
     flyTitle: ``,
     title: `Erdogan’s dilemma`,
@@ -88,7 +88,7 @@ const list = [
       src: `http://cdn.static-economist.com/sites/default/files/imagecache/full-width/images/articles/20140110_ldp006_l.jpg`,
       title: `Just an image`,
     },
-    type: `default`,
+    variantName: `default`,
     section: `Leaders`,
     flyTitle: ``,
     title: `The coming tech-lash`,
@@ -108,7 +108,7 @@ const list = [
       src: `http://cdn.static-economist.com/sites/default/files/imagecache/original-size/20151003_WOM001_473.png`,
       title: `Just an image`,
     },
-    type: `default`,
+    variantName: `default`,
     section: `Leaders`,
     flyTitle: `The UN, religion and development`,
     title: `Migration crisis`,
@@ -125,5 +125,5 @@ const list = [
   },
 ];
 export default (
-  <WinHomePage list={list}/>
+  <WinHomePage articleList={articleList}/>
 );

--- a/index.css
+++ b/index.css
@@ -1,17 +1,18 @@
 @import '@economist/component-win-teaser';
 @import '@economist/component-font-officina';
+@import '@economist/component-font-neutra2';
 
-.row-01 {
+.article-container {
   display: flex;
   flex-wrap: wrap;
 }
 
-.row-01 .default__teaser{
+.article-container .default__teaser{
   width: 31.3%;
   float: left;
 }
 
-.row-01 .default__teaser:nth-child(3n+2) {
+.article-container .default__teaser:nth-child(3n+2) {
   margin: 0 3%;
 }
 
@@ -46,35 +47,39 @@
 }
 
 .default__teaser .teaser__title {
-  font-size: 26px;
-  line-height: 30px;
+  font-size: 28px;
+  line-height: 32px;
   margin-bottom: 10px;
 }
 
 .default__teaser .teaser__text {
-    padding: 6% 0;
+  padding: 6% 0;
 }
 
-.row-01 .default__teaser:nth-child(-n+3) {
+.hero__teaser .teaser__group-image {
+  overflow: hidden;
+}
+
+.article-container .default__teaser:nth-child(-n+3) {
   order: 1;
 }
 
-.row-01 .default__teaser:nth-child(n+4):nth-child(-n+6) {
+.article-container .default__teaser:nth-child(n+4):nth-child(-n+6) {
   order: 3;
 }
 
 @media screen and (max-width: 790px) {
 
-  .row-01 .default__teaser {
+  .article-container .default__teaser {
     margin: 0 !important;
     width: 48.5%;
   }
 
-  .row-01 .default__teaser:nth-child(-2n+7) {
+  .article-container .default__teaser:nth-child(-2n+7) {
     margin-right: 3% !important;
   }
 
-  .row-01 .default__teaser:nth-child(-n+2) {
+  .article-container .default__teaser:nth-child(-n+2) {
     order: 1;
   }
   .advert-panel {
@@ -82,27 +87,30 @@
     margin-bottom: 5%;
   }
 
-  .row-01 .default__teaser:nth-child(n+3) {
+  .article-container .default__teaser:nth-child(n+3) {
     order: 3;
   }
 }
 
-
 @media screen and (max-width: 560px) {
-  .row-01 .default__teaser {
+  .article-container .default__teaser {
     margin: 0 !important;
     margin-right: 0 !important;
     width: 100%;
   }
 
-  .row-01 .default__teaser:nth-child(-2n+7) {
+  .article-container .default__teaser:nth-child(-2n+7) {
     margin-right: 0 !important;
   }
 
-  .hero__teaser .teaser__group-image img {
-    transform: translateX(-8%);
-  }
   .advert-panel {
     margin-bottom: 12%;
+  }
+}
+
+@media screen and (max-width: 480px) {
+  .hero__teaser .teaser__img  {
+    width: 175%;
+    transform: translateX(-20%);
   }
 }

--- a/index.css
+++ b/index.css
@@ -1,0 +1,108 @@
+@import '@economist/component-win-teaser';
+@import '@economist/component-font-officina';
+
+.row-01 {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.row-01 .default__teaser{
+  width: 31.3%;
+  float: left;
+}
+
+.row-01 .default__teaser:nth-child(3n+2) {
+  margin: 0 3%;
+}
+
+.advert-panel  {
+  font-family: "Officina";
+  width: 100%;
+  display: inline-table;
+  margin: 3% 0;
+  position: relative;
+  order: 2;
+}
+
+.ad-panel__container {
+  background-color: #f0f0f0;
+  padding: 3%;
+}
+
+.ad-panel__title {
+  color: var(--color-mid-grey);
+}
+
+.ad-panel__container iframe {
+  margin: 0 auto;
+  display: block;
+}
+
+/*fix for firefox*/
+@-moz-document url-prefix() {
+  .advert-panel  {
+    margin: 30px 0;
+  }
+}
+
+.default__teaser .teaser__title {
+  font-size: 26px;
+  line-height: 30px;
+  margin-bottom: 10px;
+}
+
+.default__teaser .teaser__text {
+    padding: 6% 0;
+}
+
+.row-01 .default__teaser:nth-child(-n+3) {
+  order: 1;
+}
+
+.row-01 .default__teaser:nth-child(n+4):nth-child(-n+6) {
+  order: 3;
+}
+
+@media screen and (max-width: 790px) {
+
+  .row-01 .default__teaser {
+    margin: 0 !important;
+    width: 48.5%;
+  }
+
+  .row-01 .default__teaser:nth-child(-2n+7) {
+    margin-right: 3% !important;
+  }
+
+  .row-01 .default__teaser:nth-child(-n+2) {
+    order: 1;
+  }
+  .advert-panel {
+    order: 2;
+    margin-bottom: 5%;
+  }
+
+  .row-01 .default__teaser:nth-child(n+3) {
+    order: 3;
+  }
+}
+
+
+@media screen and (max-width: 560px) {
+  .row-01 .default__teaser {
+    margin: 0 !important;
+    margin-right: 0 !important;
+    width: 100%;
+  }
+
+  .row-01 .default__teaser:nth-child(-2n+7) {
+    margin-right: 0 !important;
+  }
+
+  .hero__teaser .teaser__group-image img {
+    transform: translateX(-8%);
+  }
+  .advert-panel {
+    margin-bottom: 12%;
+  }
+}

--- a/index.es6
+++ b/index.es6
@@ -6,14 +6,14 @@ const today = new Date();
 export default class WinHomePage extends React.Component {
   static get propTypes() {
     return {
-      list: React.PropTypes.array.isRequired,
+      articleList: React.PropTypes.array.isRequired,
     };
   }
   static get defaultProps() {
   }
   render() {
     const winteaserList = [];
-    this.props.list.map((teaser) => {
+    this.props.articleList.map((teaser) => {
       winteaserList.push(
         <WinTeaser {...teaser} key={teaser.teaserId} />
       );
@@ -25,7 +25,7 @@ export default class WinHomePage extends React.Component {
             src: `http://cdn.static-economist.com/sites/default/files/imagecache/full-width/images/articles/20140110_ldp001_l.jpg`,
             title: `Just an image`,
           }}
-          type= "hero"
+          variantName= "hero"
           section="United States"
           flyTitle="The UN, religion and development"
           title="Your chance, Mr Obama"
@@ -40,7 +40,7 @@ export default class WinHomePage extends React.Component {
           itemProp="blogPost"
           teaserId={"100092"}
         />
-          <div className="row-01">
+          <div className="article-container">
           {winteaserList}
             <div className="advert-panel">
               <AdPanel adTag="/5605/teg.fmsq/wdif/busi" reserveHeight={250} />

--- a/index.es6
+++ b/index.es6
@@ -1,0 +1,52 @@
+import React from 'react';
+import WinTeaser from '../component-win-teaser';
+import AdPanel from '../component-ad-panel';
+
+const today = new Date();
+export default class WinHomePage extends React.Component {
+  static get propTypes() {
+    return {
+      list: React.PropTypes.array.isRequired,
+    };
+  }
+  static get defaultProps() {
+  }
+  render() {
+    const winteaserList = [];
+    this.props.list.map((teaser) => {
+      winteaserList.push(
+        <WinTeaser {...teaser} key={teaser.teaserId} />
+      );
+    });
+    return (
+      <div className="world-in-homepage--container">
+        <WinTeaser
+          image={{
+            src: `http://cdn.static-economist.com/sites/default/files/imagecache/full-width/images/articles/20140110_ldp001_l.jpg`,
+            title: `Just an image`,
+          }}
+          type= "hero"
+          section="United States"
+          flyTitle="The UN, religion and development"
+          title="Your chance, Mr Obama"
+          dateTime={today}
+          text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam."
+          link={{
+            href: `http://www.economist.com/blogs/erasmus/2015/09/un-religion-and-development-0`,
+          }}
+          itemType="http://schema.org/BlogPosting"
+          itemProp="blogPost"
+          teaserId={"100092"}
+        />
+          <div className="row-01">
+          {winteaserList}
+            <div className="advert-panel">
+              <AdPanel adTag="/5605/teg.fmsq/wdif/busi" reserveHeight={250} />
+            </div>
+          </div>
+      </div>
+    );
+  }
+}

--- a/package.json
+++ b/package.json
@@ -128,7 +128,8 @@
     "watch": "parallelshell 'npm run doc:watch' 'npm run prepublish:watch' 'npm run serve'"
   },
   "dependencies": {
-    "@economist/component-font-officina": "^1.0.0"
+    "@economist/component-font-officina": "^1.0.0",
+    "@economist/component-font-neutra2": "^1.0.0"
   },
   "devDependencies": {
     "@economist/component-devpack": "^3.4.2",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,166 @@
+{
+  "name": "@economist/component-win-homepage",
+  "version": "1.0.0",
+  "description": "Home page for the World in 2016",
+  "author": "The Economist (http://economist.com)",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/economist-components/component-win-homepage.git"
+  },
+  "homepage": "https://github.com/economist-components/component-win-homepage#readme",
+  "bugs": {
+    "url": "https://github.com/economist-components/component-win-homepage/issues"
+  },
+  "main": "index.js",
+  "files": [
+    "*.js",
+    "*.css",
+    "!karma.conf.js",
+    "!testbundle.js"
+  ],
+  "browserify": {
+    "transform": [
+      "babelify"
+    ]
+  },
+  "babel": {
+    "stage": 0,
+    "loose": "all",
+    "compact": false
+  },
+  "eslintConfig": {
+    "extends": [
+      "strict",
+      "strict-react"
+    ]
+  },
+  "devpack-doc": {
+    "demohtml": {
+      "cmd": "babel-node -p \"require('react').renderToString(require('./example'))\""
+    },
+    "css": [
+      {
+        "src": "./node_modules/mocha/mocha.css"
+      },
+      "./bundle.css"
+    ],
+    "js": [
+      {
+        "src": "./node_modules/mocha/mocha.js"
+      },
+      {
+        "src": "./node_modules/chai/chai.js"
+      },
+      {
+        "src": "./node_modules/chai-things/lib/chai-things.js"
+      },
+      {
+        "src": "./node_modules/chai-spies/chai-spies.js"
+      },
+      {
+        "contents": "chai.should();mocha.setup('bdd');"
+      },
+      "./testbundle.js",
+      {
+        "contents": "window.React = require('react');"
+      },
+      {
+        "contents": "require('react').render(require('example'),document.getElementById('component-preview'));"
+      },
+      {
+        "contents": "if(document.getElementById('mocha')){mocha.checkLeaks();mocha.run();}"
+      },
+      {
+        "contents": "</script><!-- lol html injection -->    <script type=\"text/javascript\"> (function() { var path = '//easy.myfonts.net/v2/js?sid=207020(font-family=FF+Milo+Serif+Pro)&sid=207025(font-family=FF+Milo+Serif+Pro+Med+Italic)&sid=207029(font-family=FF+Milo+Serif+Pro+Bold)&key=ADKczqjSur', protocol = ('https:' == document.location.protocol ? 'https:' : 'http:'), trial = document.createElement('script'); trial.type = 'text/javascript'; trial.async = true; trial.src = protocol + path; var head = document.getElementsByTagName(\"head\")[0]; head.appendChild(trial); })(); </script> <script type=\"text/javascript\"> (function() { var path = '//easy.myfonts.net/v2/js?sid=274518(font-family=Halifax+Regular)&sid=274519(font-family=Halifax+Light)&sid=274524(font-family=Halifax+Bold)&key=LUwLgIpMrH', protocol = ('https:' == document.location.protocol ? 'https:' : 'http:'), trial = document.createElement('script'); trial.type = 'text/javascript'; trial.async = true; trial.src = protocol + path; var head = document.getElementsByTagName(\"head\")[0]; head.appendChild(trial); })(); </script>     <script>/* end my html injection */"
+      }
+    ],
+    "sections": [
+      {
+        "title": "Readme",
+        "type": "markdown",
+        "src": "./README.md"
+      },
+      {
+        "title": "Example Code",
+        "type": "code",
+        "src": "./example.es6"
+      },
+      {
+        "title": "Tests",
+        "type": "html",
+        "contents": "<div id='mocha' class='test-output'></div>"
+      }
+    ]
+  },
+  "watch": {
+    "doc:html": [
+      "README.md",
+      "./*.js",
+      "package.json"
+    ]
+  },
+  "config": {
+    "lint_opts": "--ignore-path .gitignore --ext .es6",
+    "testbundle_opts": "-r react -r .:./index.es6 -r ./example.js:example ./test/index.js -o testbundle.js",
+    "ghpages_files": "*.html *.css *.js"
+  },
+  "scripts": {
+    "build": "npm-assets .",
+    "ci": "./build.sh",
+    "doc": "parallelshell 'npm run doc:html' 'npm run doc:js' 'npm run doc:css'",
+    "doc:css": "cssnext --sourcemap example.css bundle.css",
+    "doc:css:watch": "npm run doc:css -- --watch",
+    "doc:html": "devpack-doc index standalone",
+    "doc:html:watch": "npm-watch",
+    "doc:js": "npm run prepublish && browserify -d $npm_package_config_testbundle_opts",
+    "doc:js:watch": "watchify $npm_package_config_testbundle_opts",
+    "doc:watch": "parallelshell 'npm run doc:html:watch' 'npm run doc:js:watch' 'npm run doc:css:watch'",
+    "lint": "eslint $npm_package_config_lint_opts .",
+    "pages": "git stash save -u pages-stash && git branch -D gh-pages; git checkout --orphan gh-pages && git add -f $npm_package_config_ghpages_files && git commit -anm'ghpages' && git push origin HEAD:gh-pages -f",
+    "prepages": "npm run doc",
+    "prepublish": "babel . -d . -x .es6 --ignore node_modules",
+    "prepublish:watch": "npm run prepublish -- -w",
+    "pretest": "npm run lint",
+    "provision": "devpack-configure ./package.json",
+    "serve": "browser-sync start --server --files '*.{html,js}'",
+    "test": "karma start",
+    "watch": "parallelshell 'npm run doc:watch' 'npm run prepublish:watch' 'npm run serve'"
+  },
+  "dependencies": {
+    "@economist/component-font-officina": "^1.0.0"
+  },
+  "devDependencies": {
+    "@economist/component-devpack": "^3.4.2",
+    "babel": "^5.8.23",
+    "babelify": "^6.3.0",
+    "browser-sync": "^2.8.2",
+    "browserify": "^11.0.1",
+    "chai": "^3.2.0",
+    "chai-spies": "^0.6.0",
+    "chai-things": "^0.2.0",
+    "cssnext": "^1.8.4",
+    "eslint": "^1.3.1",
+    "eslint-config-strict": "^5.0.0",
+    "eslint-config-strict-react": "^2.0.0",
+    "eslint-plugin-filenames": "^0.1.2",
+    "eslint-plugin-react": "^3.3.1",
+    "karma-chai": "^0.1.0",
+    "karma-mocha": "^0.2.0",
+    "karma-sauce-launcher": "^0.2.14",
+    "mocha": "^2.2.5",
+    "npm-assets": "^0.1.0",
+    "npm-watch": "0.0.1",
+    "parallelshell": "^2.0.0",
+    "pre-commit": "^1.0.10",
+    "react": "^0.14.0||^0.14.0-rc",
+    "react-addons-test-utils": "^0.14.0",
+    "watchify": "^3.4.0"
+  },
+  "peerDependencies": {
+    "react": "^0.14.0||^0.14.0-rc"
+  },
+  "pre-commit": [
+    "lint"
+  ]
+}

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,1 @@
+{"extends":["strict","strict-react","strict/mocha"]}

--- a/test/index.es6
+++ b/test/index.es6
@@ -1,0 +1,18 @@
+import Teaser from '../index.es6';
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
+
+describe(`A teaser`, () => {
+  describe(`it's a React component`, () => {
+    it('is compatible with React.Component', () => {
+      Teaser.should.be.a('function').and.respondTo('render');
+    });
+    it(`it's renders a React element`, () => {
+      React.isValidElement(
+        <Teaser
+          title="Required"
+          teaserId={'1'}
+        />).should.equal(true);
+    });
+  });
+});


### PR DESCRIPTION
This component uses https://github.com/the-economist-editorial/component-win-teaser to generate the hero and homepage teaser 'tiles'.

Also currently uses https://github.com/the-economist-editorial/component-ad-panel as a dependancy.