### PR TITLE
Refactored component + css

### DIFF
--- a/example.es6
+++ b/example.es6
@@ -2,7 +2,7 @@ import React from 'react';
 import WinHomePage from './';
 
 const today = new Date();
-const articleList = [
+const articles = [
   {
     image: {
       src: `http://cdn.static-economist.com/sites/default/files/imagecache/full-width/images/articles/20140110_usd001_l.jpg`,
@@ -123,7 +123,27 @@ const articleList = [
     itemProp: ``,
     teaserId: `6`,
   },
+  {
+    image: {
+      src: `http://cdn.static-economist.com/sites/default/files/imagecache/full-width/images/2015/09/blogs/erasmus/20150905_blp516_apple_news.jpg`,
+      title: `Just an image`,
+    },
+    variantName: `default`,
+    section: `Leaders`,
+    flyTitle: `Diverse, desperate migrants have divided European Christians`,
+    title: `Migrants, Christianity and Europe`,
+    dateTime: today,
+    text: `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+    eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+    minim veniam.`,
+    link: {
+      href: `http://www.economist.com/blogs/erasmus/2015/09`,
+    },
+    itemType: ``,
+    itemProp: ``,
+    teaserId: `7`,
+  },
 ];
 export default (
-  <WinHomePage articleList={articleList}/>
+  <WinHomePage articles={articles}/>
 );

--- a/index.css
+++ b/index.css
@@ -2,21 +2,26 @@
 @import '@economist/component-font-officina';
 @import '@economist/component-font-neutra2';
 
-.article-container {
+.world-in-homepage {
   display: flex;
   flex-wrap: wrap;
 }
 
-.article-container .default__teaser{
+.world-in-homepage .hero__teaser {
+  flex: 1 100%;
+}
+
+.world-in-homepage .default__teaser {
   width: 31.3%;
   float: left;
 }
 
-.article-container .default__teaser:nth-child(3n+2) {
+/* 1 2 (3) 4 5 (6) 7 8 (9)... */
+.world-in-homepage .default__teaser:nth-child(3n+3) {
   margin: 0 3%;
 }
 
-.advert-panel  {
+.world-in-homepage__advert-panel  {
   font-family: "Officina";
   width: 100%;
   display: inline-table;
@@ -25,92 +30,94 @@
   order: 2;
 }
 
-.ad-panel__container {
+.world-in-homepage__advert-panel .ad-panel__container {
   background-color: #f0f0f0;
   padding: 3%;
 }
 
-.ad-panel__title {
+.world-in-homepage__advert-panel .ad-panel__title {
   color: var(--color-mid-grey);
 }
 
-.ad-panel__container iframe {
+.world-in-homepage__advert-panel .ad-panel__container iframe {
   margin: 0 auto;
   display: block;
 }
 
-/*fix for firefox*/
-@-moz-document url-prefix() {
-  .advert-panel  {
-    margin: 30px 0;
-  }
-}
-
-.default__teaser .teaser__title {
+.world-in-homepage .default__teaser .teaser__title {
   font-size: 28px;
   line-height: 32px;
   margin-bottom: 10px;
 }
 
-.default__teaser .teaser__text {
+.world-in-homepage .default__teaser .teaser__text {
   padding: 6% 0;
 }
 
-.hero__teaser .teaser__group-image {
+.world-in-homepage .hero__teaser .teaser__group-image {
   overflow: hidden;
 }
 
-.article-container .default__teaser:nth-child(-n+3) {
+/* (1) (2) (3) (4) 5 6 7 8 9 10 */
+.world-in-homepage .default__teaser:nth-child(-n+4) {
   order: 1;
 }
 
-.article-container .default__teaser:nth-child(n+4):nth-child(-n+6) {
+/* 1 2 3 4 (5) (6) (7) 8 9 10 */
+.world-in-homepage .default__teaser:nth-child(n+5):nth-child(-n+7),{
   order: 3;
 }
 
 @media screen and (max-width: 790px) {
 
-  .article-container .default__teaser {
-    margin: 0 !important;
+  .world-in-homepage .default__teaser {
     width: 48.5%;
   }
 
-  .article-container .default__teaser:nth-child(-2n+7) {
-    margin-right: 3% !important;
-  }
-
-  .article-container .default__teaser:nth-child(-n+2) {
+  /* 1 (2) (3) 4 5 6 7 8 9 10 */
+  .world-in-homepage .default__teaser:nth-child(n+2):nth-child(-n+3) {
     order: 1;
   }
-  .advert-panel {
+
+  /* 1 (2) 3 (4) 5 (6) 7 (8) 9 (10)... */
+  .world-in-homepage .default__teaser:nth-child(2n+2) {
+    margin: 0 3% 0 0;
+  }
+
+  /* (1) 2 (3) 4 (5) 6 (7) 8 (9) 10... */
+  .world-in-homepage .default__teaser:nth-child(2n+1) {
+    margin: 0;
+  }
+
+  .world-in-homepage__advert-panel {
     order: 2;
     margin-bottom: 5%;
   }
 
-  .article-container .default__teaser:nth-child(n+3) {
+  /* 1 2 3 (4) (5) (6) (7) (8) (9) (10)... */
+  .world-in-homepage .default__teaser:nth-child(n+4) {
     order: 3;
   }
+
 }
 
 @media screen and (max-width: 560px) {
-  .article-container .default__teaser {
-    margin: 0 !important;
-    margin-right: 0 !important;
+
+  /* Specificity override :( */
+  .world-in-homepage .default__teaser:nth-child(n) {
+    margin: 0;
     width: 100%;
   }
 
-  .article-container .default__teaser:nth-child(-2n+7) {
-    margin-right: 0 !important;
-  }
-
-  .advert-panel {
+  .world-in-homepage__advert-panel {
     margin-bottom: 12%;
   }
+
 }
 
 @media screen and (max-width: 480px) {
-  .hero__teaser .teaser__img  {
+  .world-in-homepage .hero__teaser .teaser__img  {
     width: 175%;
-    transform: translateX(-20%);
+    transform: translateX(-25%);
   }
 }

--- a/index.es6
+++ b/index.es6
@@ -1,52 +1,40 @@
 import React from 'react';
-import WinTeaser from '../component-win-teaser';
-import AdPanel from '../component-ad-panel';
+import WinTeaser from '@economist/component-win-teaser';
+import AdPanel from '@economist/component-ad-panel';
 
-const today = new Date();
-export default class WinHomePage extends React.Component {
-  static get propTypes() {
-    return {
-      articleList: React.PropTypes.array.isRequired,
-    };
+export function WinHomepageAdPanel(props) {
+  return (
+    <aside className="world-in-homepage__advert-panel">
+      <AdPanel {...props}/>
+    </aside>
+  );
+}
+if (process.env.NODE_ENV !== 'production') {
+  WinHomepageAdPanel.propTypes = AdPanel.propTypes;
+}
+
+export default function WinHomePage({
+  articles,
+  advert = {
+    adTag: '/5605/teg.fmsq/wdif/busi',
+    reserveHeight: 250,
   }
-  static get defaultProps() {
+}) {
+  const elements = articles.map((article, index) => (
+    <WinTeaser {...article} key={article.teaserId} variantName={index === 0 ? 'hero' : 'default'}/>
+  ));
+  if (advert) {
+    elements.push(<WinHomepageAdPanel {...advert} key="_ad"/>);
   }
-  render() {
-    const winteaserList = [];
-    this.props.articleList.map((teaser) => {
-      winteaserList.push(
-        <WinTeaser {...teaser} key={teaser.teaserId} />
-      );
-    });
-    return (
-      <div className="world-in-homepage--container">
-        <WinTeaser
-          image={{
-            src: `http://cdn.static-economist.com/sites/default/files/imagecache/full-width/images/articles/20140110_ldp001_l.jpg`,
-            title: `Just an image`,
-          }}
-          variantName= "hero"
-          section="United States"
-          flyTitle="The UN, religion and development"
-          title="Your chance, Mr Obama"
-          dateTime={today}
-          text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-          minim veniam."
-          link={{
-            href: `http://www.economist.com/blogs/erasmus/2015/09/un-religion-and-development-0`,
-          }}
-          itemType="http://schema.org/BlogPosting"
-          itemProp="blogPost"
-          teaserId={"100092"}
-        />
-          <div className="article-container">
-          {winteaserList}
-            <div className="advert-panel">
-              <AdPanel adTag="/5605/teg.fmsq/wdif/busi" reserveHeight={250} />
-            </div>
-          </div>
-      </div>
-    );
-  }
+  return (
+    <main className="world-in-homepage">{elements}</main>
+  );
+}
+if (process.env.NODE_ENV !== 'production') {
+  WinHomePage.propTypes = {
+    articles: React.PropTypes.arrayOf(
+      React.PropTypes.shape(WinTeaser.propTypes)
+    ).isRequired,
+    advert: React.PropTypes.shape(WinHomepageAdPanel.propTypes),
+  };
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,77 @@
+module.exports = (config) => {
+  const browsers = {
+    SauceChromeLatest: {
+      base: 'SauceLabs',
+      browserName: 'Chrome',
+    },
+    SauceFirefoxLatest: {
+      base: 'SauceLabs',
+      browserName: 'Firefox',
+    },
+    SauceSafariLatest: {
+      base: 'SauceLabs',
+      browserName: 'Safari',
+    },
+    SauceInternetExplorerLatest: {
+      base: 'SauceLabs',
+      browserName: 'Internet Explorer',
+    },
+    SauceEdgeLatest: {
+      base: 'SauceLabs',
+      browserName: 'MicrosoftEdge',
+    },
+    SauceIphoneLatest: {
+      base: 'SauceLabs',
+      browserName: 'iPad',
+    },
+    SauceAndroidLatest: {
+      base: 'SauceLabs',
+      browserName: 'Android',
+    },
+  };
+  const isSaucelabs = process.env.SAUCE_USERNAME && process.env.SAUCE_ACCESS_KEY;
+  config.set({
+    basePath: '',
+    frameworks: [
+      'mocha',
+      'chai',
+    ],
+    files: [
+      require.resolve('chai-spies/chai-spies'),
+      require.resolve('chai-things/lib/chai-things'),
+      'testbundle.js',
+    ],
+    exclude: [
+    ],
+    preprocessors: {
+    },
+    reporters: [
+      'progress',
+      'saucelabs',
+    ],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: false,
+    customLaunchers: browsers,
+    browserDisconnectTimeout: 1000 * 60 * 2,
+    browserNoActivityTimeout: 1000 * 60 * 2,
+    phantomjsLauncher: {
+      exitOnResourceError: true,
+    },
+    sauceLabs: {
+      testName: require('./package').name,
+      startConnect: true,
+      build: (() => {
+        if (process.env.GO_PIPELINE_NAME && process.env.GO_PIPELINE_LABEL) {
+          return `${process.env.GO_PIPELINE_NAME}-${process.env.GO_PIPELINE_LABEL}`;
+        } else if (process.env.CI_BUILD_NUMBER) {
+          return `ci-build-${process.env.CI_BUILD_NUMBER}`;
+        }
+        return `localbuild-${new Date().toJSON()}`;
+      })(),
+    },
+    browsers: isSaucelabs ? Object.keys(browsers) : [ 'PhantomJS2' ],
+    singleRun: true,
+  });
+};

--- a/package.json
+++ b/package.json
@@ -124,12 +124,15 @@
     "pretest": "npm run lint",
     "provision": "devpack-configure ./package.json",
     "serve": "browser-sync start --server --files '*.{html,js}'",
+    "pretest": "npm run doc:js",
     "test": "karma start",
     "watch": "parallelshell 'npm run doc:watch' 'npm run prepublish:watch' 'npm run serve'"
   },
   "dependencies": {
+    "@economist/component-ad-panel": "^1.0.3",
+    "@economist/component-font-neutra2": "^1.0.0",
     "@economist/component-font-officina": "^1.0.0",
-    "@economist/component-font-neutra2": "^1.0.0"
+    "@economist/component-win-teaser": "^1.0.11"
   },
   "devDependencies": {
     "@economist/component-devpack": "^3.4.2",
@@ -146,13 +149,17 @@
     "eslint-config-strict-react": "^2.0.0",
     "eslint-plugin-filenames": "^0.1.2",
     "eslint-plugin-react": "^3.3.1",
+    "karma": "^0.13.15",
     "karma-chai": "^0.1.0",
     "karma-mocha": "^0.2.0",
+    "karma-phantomjs-launcher": "^0.2.1",
+    "karma-phantomjs2-launcher": "^0.3.2",
     "karma-sauce-launcher": "^0.2.14",
     "mocha": "^2.2.5",
     "npm-assets": "^0.1.0",
     "npm-watch": "0.0.1",
     "parallelshell": "^2.0.0",
+    "phantomjs": "^1.9.18",
     "pre-commit": "^1.0.10",
     "react": "^0.14.0||^0.14.0-rc",
     "react-addons-test-utils": "^0.14.0",

--- a/test/index.es6
+++ b/test/index.es6
@@ -1,18 +1,125 @@
-import Teaser from '../index.es6';
+import chai from 'chai';
+const should = chai.should();
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
+import WinHomepage, {WinHomepageAdPanel} from '../index';
+import WinTeaser from '@economist/component-win-teaser';
+import AdPanel from '@economist/component-ad-panel';
 
-describe(`A teaser`, () => {
-  describe(`it's a React component`, () => {
-    it('is compatible with React.Component', () => {
-      Teaser.should.be.a('function').and.respondTo('render');
-    });
-    it(`it's renders a React element`, () => {
-      React.isValidElement(
-        <Teaser
-          title="Required"
-          teaserId={'1'}
-        />).should.equal(true);
-    });
+describe('WIN Homepage', () => {
+
+  it('is compatible with React.Component', () => {
+    should.exist(WinHomepage);
+    WinHomepage.should.be.a('function');
   });
+
+  it('renders a React element', () => {
+    React.isValidElement(<WinHomepage articles={[]}/>).should.equal(true);
+  });
+
+  it('has proptypes', () => {
+    WinHomepage.propTypes.should.be.an('object');
+  });
+
+  describe('rendering', () => {
+
+    it('renders a main component, with an AdPanel component', () => {
+      WinHomepage({ articles: [] }).should.deep.equal(
+        <main className="world-in-homepage">
+          {[
+            <WinHomepageAdPanel adTag="/5605/teg.fmsq/wdif/busi" reserveHeight={250} key="_ad"/>,
+          ]}
+        </main>
+      )
+    });
+
+    it('allows AdPanel props to be overriden', () => {
+      WinHomepage({ articles: [], advert: { adTag: 'foo', reserveHeight: 1 } }).should.deep.equal(
+        <main className="world-in-homepage">
+          {[
+            <WinHomepageAdPanel adTag="foo" reserveHeight={1} key="_ad"/>,
+          ]}
+        </main>
+      )
+    });
+
+    it('renders first article in `articles` as <WinTeaser variantName=hero/>', () => {
+      const articles = [
+        {
+          dateFormat: () => {},
+          teaserId: '1',
+          title: 'Foo',
+        },
+      ];
+      WinHomepage({ articles }).should.deep.equal(
+        <main className="world-in-homepage">
+          {[
+            <WinTeaser {...articles[0]} key="1" variantName="hero"/>,
+            <WinHomepageAdPanel adTag="/5605/teg.fmsq/wdif/busi" reserveHeight={250} key="_ad"/>,
+          ]}
+        </main>
+      )
+    });
+
+    it('renders subsequent articles as <WinTeaser variantName=default/>', () => {
+      const articles = [
+        {
+          dateFormat: () => {},
+          teaserId: '2',
+          title: 'Foo',
+        },
+        {
+          dateFormat: () => {},
+          teaserId: '1',
+          title: 'Foo',
+        },
+        {
+          dateFormat: () => {},
+          teaserId: '3',
+          title: 'Foo',
+        },
+      ];
+      WinHomepage({ articles }).should.deep.equal(
+        <main className="world-in-homepage">
+          {[
+            <WinTeaser {...articles[0]} key="2" variantName="hero"/>,
+            <WinTeaser {...articles[1]} key="1" variantName="default"/>,
+            <WinTeaser {...articles[2]} key="3" variantName="default"/>,
+            <WinHomepageAdPanel adTag="/5605/teg.fmsq/wdif/busi" reserveHeight={250} key="_ad"/>,
+          ]}
+        </main>
+      )
+    });
+
+  });
+
+});
+
+describe('WinHomepageAdPanel', () => {
+
+  it('is compatible with React.Component', () => {
+    should.exist(WinHomepageAdPanel);
+    WinHomepageAdPanel.should.be.a('function');
+  });
+
+  it('renders a React element', () => {
+    React.isValidElement(<WinHomepageAdPanel/>).should.equal(true);
+  });
+
+  it('has proptypes', () => {
+    WinHomepageAdPanel.propTypes.should.be.an('object');
+  });
+
+  describe('rendering', () => {
+
+    it('renders an aside with <AdPanel {...props}/>', () => {
+      WinHomepageAdPanel({ foo: 'bar', baz: 'bing' }).should.deep.equal(
+        <aside className="world-in-homepage__advert-panel">
+          <AdPanel foo="bar" baz="bing"/>
+        </aside>
+      )
+    });
+
+  });
+
 });


### PR DESCRIPTION
 - Make win-teaser & ad-panel proper dependencies
 - Convert win-homepage to a stateless function component
 - Remove hardcoded hero teaser, and make first item always hero
 - s/articleList/articles.
 - Clean up CSS to no longer use `!important`
 - Add tests!